### PR TITLE
Update JC2.py

### DIFF
--- a/JC2.py
+++ b/JC2.py
@@ -813,8 +813,9 @@ class JoyCaption2_simple:
                 model = self.previous_model
 
         except Exception as e:
-            print(f"Error loading model: {e}")
-            return None
+            # print(f"Error loading model: {e}")
+            raise Exception(f"Error loading model: {e}")
+            # return None
 
         print(f"Model loaded on {model_loaded_on}")
 


### PR DESCRIPTION
```
return None
```
is sometimes confusing for debugging. it will cause other error within comfy. Like
```
"./ComfyUI/execution.py", line 175, in merge_result_data
output_is_list = [False] * len(results[0])
TypeError: object of type 'NoneType' has no len()
```
Raise the error directly will help coders and users to point the position where is original error 